### PR TITLE
Make BKTree code more idiomatic

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,13 +31,13 @@ impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein
         let str_a: &str = a.as_ref();
         let str_b: &str = b.as_ref();
 
-        let len_a: u64 = str_a.chars().collect::<Vec<char>>().len() as u64;
-        let len_b: u64 = str_b.chars().collect::<Vec<char>>().len() as u64;
+        let len_a = str_a.chars().count();
+        let len_b = str_b.chars().count();
         if len_a == 0 {
-            return len_b;
+            return len_b as u64;
         }
         if len_b == 0 {
-            return len_a;
+            return len_a as u64;
         }
 
         // This is a case-insensitive algorithm
@@ -45,7 +45,7 @@ impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein
         let b_lower = str_b.to_lowercase();
 
         // Initialize the array
-        let mut d: Vec<Vec<u64>> = Vec::new();
+        let mut d: Vec<Vec<usize>> = Vec::new();
         for j in 0..(len_b + 1) {
             let mut cur_vec = Vec::new();
             for i in 0..(len_a + 1) {
@@ -60,10 +60,8 @@ impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein
             d.push(cur_vec);
         }
 
-        for j in 0..len_b as usize {
-            for i in 0..len_a as usize {
-                let chr_a = a_lower.chars().nth(i).unwrap();
-                let chr_b = b_lower.chars().nth(j).unwrap();
+        for (j, chr_b) in b_lower.chars().enumerate() {
+            for (i, chr_a) in a_lower.chars().enumerate() {
                 if chr_a == chr_b {
                     // If they're the same, then don't modify the value
                     d[j + 1][i + 1] = d[j][i];
@@ -77,6 +75,6 @@ impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein
             }
         }
 
-        d[len_b as usize][len_a as usize]
+        d[len_b][len_a] as u64
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4,6 +4,8 @@
 
 use std::cmp::min;
 
+use Metric;
+
 /// This calculates the Levenshtein distance between two strings.
 ///
 /// The [distance metric itself][1] is calculated using the [Wagner-Fischer][2]
@@ -12,63 +14,69 @@ use std::cmp::min;
 /// # Examples
 ///
 /// ```
-/// use bk_tree::metrics::levenshtein;
+/// use bk_tree::Metric;
+/// use bk_tree::metrics::Levenshtein;
 ///
-/// assert_eq!(levenshtein("bar", "baz"), 1);
-/// assert_eq!(levenshtein("kitten", "sitting"), 3);
+/// assert_eq!(Levenshtein.distance("bar", "baz"), 1);
+/// assert_eq!(Levenshtein.distance("kitten", "sitting"), 3);
 /// ```
 ///
 /// [1]: https://en.wikipedia.org/wiki/Levenshtein_distance
 /// [2]: https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm
-pub fn levenshtein<S: ToString>(a: S, b: S) -> u64 {
-    let str_a: &str = &a.to_string();
-    let str_b: &str = &b.to_string();
+pub struct Levenshtein;
 
-    let len_a: u64 = str_a.chars().collect::<Vec<char>>().len() as u64;
-    let len_b: u64 = str_b.chars().collect::<Vec<char>>().len() as u64;
-    if len_a == 0 {
-        return len_b;
-    }
-    if len_b == 0 {
-        return len_a;
-    }
+impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein
+{
+    fn distance(&self, a: &K, b: &K) -> u64 {
+        let str_a: &str = a.as_ref();
+        let str_b: &str = b.as_ref();
 
-    // This is a case-insensitive algorithm
-    let a_lower = str_a.to_lowercase();
-    let b_lower = str_b.to_lowercase();
+        let len_a: u64 = str_a.chars().collect::<Vec<char>>().len() as u64;
+        let len_b: u64 = str_b.chars().collect::<Vec<char>>().len() as u64;
+        if len_a == 0 {
+            return len_b;
+        }
+        if len_b == 0 {
+            return len_a;
+        }
 
-    // Initialize the array
-    let mut d: Vec<Vec<u64>> = Vec::new();
-    for j in 0..(len_b + 1) {
-        let mut cur_vec = Vec::new();
-        for i in 0..(len_a + 1) {
-            if j == 0 {
-                cur_vec.push(i);
-            } else if i == 0 {
-                cur_vec.push(j);
-            } else {
-                cur_vec.push(0);
+        // This is a case-insensitive algorithm
+        let a_lower = str_a.to_lowercase();
+        let b_lower = str_b.to_lowercase();
+
+        // Initialize the array
+        let mut d: Vec<Vec<u64>> = Vec::new();
+        for j in 0..(len_b + 1) {
+            let mut cur_vec = Vec::new();
+            for i in 0..(len_a + 1) {
+                if j == 0 {
+                    cur_vec.push(i);
+                } else if i == 0 {
+                    cur_vec.push(j);
+                } else {
+                    cur_vec.push(0);
+                }
+            }
+            d.push(cur_vec);
+        }
+
+        for j in 0..len_b as usize {
+            for i in 0..len_a as usize {
+                let chr_a = a_lower.chars().nth(i).unwrap();
+                let chr_b = b_lower.chars().nth(j).unwrap();
+                if chr_a == chr_b {
+                    // If they're the same, then don't modify the value
+                    d[j + 1][i + 1] = d[j][i];
+                } else {
+                    // Otherwise, pick the lowest cost option for an error
+                    let deletion = d[j + 1][i] + 1;
+                    let insertion = d[j][i + 1] + 1;
+                    let substitution = d[j][i] + 1;
+                    d[j + 1][i + 1] = min(min(deletion, insertion), substitution);
+                }
             }
         }
-        d.push(cur_vec);
-    }
 
-    for j in 0..len_b as usize {
-        for i in 0..len_a as usize {
-            let chr_a = a_lower.chars().nth(i).unwrap();
-            let chr_b = b_lower.chars().nth(j).unwrap();
-            if chr_a == chr_b {
-                // If they're the same, then don't modify the value
-                d[j + 1][i + 1] = d[j][i];
-            } else {
-                // Otherwise, pick the lowest cost option for an error
-                let deletion = d[j + 1][i] + 1;
-                let insertion = d[j][i + 1] + 1;
-                let substitution = d[j][i] + 1;
-                d[j + 1][i + 1] = min(min(deletion, insertion), substitution);
-            }
-        }
+        d[len_b as usize][len_a as usize]
     }
-
-    d[len_b as usize][len_a as usize]
 }


### PR DESCRIPTION
I refactored the code a bit to reduce the amount of cloning and allocation. The resulting design is closer to that of e.g. `HashMap`.

If you're happy with these changes then I'll remove the `Clone` constraint from `.find()` and `.find_exact()` as well.
