### PR TITLE
Update style/code with fmt and clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 authors = ["Eugene Bulkin <eugene.bulkin2@gmail.com>"]
 description = "A Rust BK-tree implementation"
 
-documentation = "http://eugene-bulkin.github.io/rust-docs/rust-bk-tree/bk_tree/index.html"
+documentation = "https://docs.rs/bk-tree/latest/bk_tree/"
 repository = "https://github.com/eugene-bulkin/rust-bk-tree"
 
 readme = "README.md"
@@ -13,4 +13,4 @@ keywords = ["fuzzy", "search", "BK-tree"]
 categories = ["data-structures", "text-processing"]
 
 [dev-dependencies]
-rand = "0.3"
+rand = "0.8.2"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rust-bk-tree
 A BK-tree implementation in Rust.
 
-[![Build Status](https://travis-ci.org/eugene-bulkin/rust-bk-tree.svg?branch=master)](https://travis-ci.org/eugene-bulkin/rust-bk-tree) [![Crates.io](https://img.shields.io/crates/v/bk-tree.svg)](https://crates.io/crates/bk-tree) [![Clippy Linting Result](http://clippy.bashy.io/github/eugene-bulkin/rust-bk-tree/master/badge.svg)](http://clippy.bashy.io/github/eugene-bulkin/rust-bk-tree/master/log)
+[![Build Status](https://travis-ci.org/eugene-bulkin/rust-bk-tree.svg?branch=master)](https://travis-ci.org/eugene-bulkin/rust-bk-tree) [![Crates.io](https://img.shields.io/crates/v/bk-tree.svg)](https://crates.io/crates/bk-tree) 
 
 [Documentation](https://docs.rs/bk-tree/)
 
@@ -27,7 +27,7 @@ tree.find("bup", 2); // returns vec!["bar", "baz", "bup"]
 
 # Benchmarks
 
-To run benchmarks, you need to have the nightly version of Rust installed. If you do (and use [multirust](/brson/multirust), for example), then you can run
+To run benchmarks, you need to have the nightly version of Rust installed. If you have rustup installed, then you can run
 
 ```
 rustup run nightly cargo bench

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,17 +1,23 @@
-#![feature(test)] extern crate test;
+#![feature(test)]
 extern crate bk_tree;
 extern crate rand;
+extern crate test;
 
-use bk_tree::BKTree;
 use bk_tree::metrics::Levenshtein;
-use test::Bencher;
+use bk_tree::BKTree;
+use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
+use test::Bencher;
 
 fn make_words<R: Rng>(rng: &mut R, n: i32) -> Vec<String> {
     let mut words: Vec<String> = Vec::new();
     for _ in 1..n {
-        let l = rng.gen_range(4, 12);
-        let s: String = rng.gen_ascii_chars().take(l).collect();
+        let l = rng.gen_range(4..12);
+        let s: String = rng
+            .sample_iter(&Alphanumeric)
+            .take(l)
+            .map(char::from)
+            .collect();
         words.push(s);
     }
     words
@@ -24,9 +30,7 @@ fn bench_find_exact(b: &mut Bencher) {
     let word = words.last().unwrap().clone();
     tree.extend(words);
 
-    b.iter(|| {
-        tree.find_exact(&word)
-    });
+    b.iter(|| tree.find_exact(&word));
 }
 
 #[bench]
@@ -36,11 +40,8 @@ fn bench_find_tol_one(b: &mut Bencher) {
     let word = words.last().unwrap().clone();
     tree.extend(words);
 
-    b.iter(|| {
-        tree.find(&word, 1)
-    });
+    b.iter(|| tree.find(&word, 1));
 }
-
 
 #[bench]
 fn bench_find_tol_two(b: &mut Bencher) {
@@ -49,9 +50,7 @@ fn bench_find_tol_two(b: &mut Bencher) {
     let word = words.last().unwrap().clone();
     tree.extend(words);
 
-    b.iter(|| {
-        tree.find(&word, 2)
-    });
+    b.iter(|| tree.find(&word, 2));
 }
 
 #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,11 @@ struct BKNode<K> {
     children: HashMap<u64, BKNode<K>>,
 }
 
-impl<K> BKNode<K>
-{
+impl<K> BKNode<K> {
     /// Constructs a new `BKNode<K>`.
-    pub fn new(key: K) -> BKNode<K>
-    {
+    pub fn new(key: K) -> BKNode<K> {
         BKNode {
-            key: key,
+            key,
             children: HashMap::new(),
         }
     }
@@ -59,7 +57,9 @@ impl<K> BKNode<K>
     }
 }
 
-impl<K> Debug for BKNode<K> where K: Debug
+impl<K> Debug for BKNode<K>
+where
+    K: Debug,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_map().entry(&self.key, &self.children).finish()
@@ -68,8 +68,7 @@ impl<K> Debug for BKNode<K> where K: Debug
 
 /// A representation of a [BK-tree](https://en.wikipedia.org/wiki/BK-tree).
 #[derive(Debug)]
-pub struct BKTree<K, M = metrics::Levenshtein>
-{
+pub struct BKTree<K, M = metrics::Levenshtein> {
     /// The root node. May be empty if nothing has been put in the tree yet.
     root: Option<BKNode<K>>,
     /// The metric being used to determine the distance between nodes on the
@@ -78,7 +77,8 @@ pub struct BKTree<K, M = metrics::Levenshtein>
 }
 
 impl<K, M> BKTree<K, M>
-    where M: Metric<K>
+where
+    M: Metric<K>,
 {
     /// Constructs a new `BKTree<K>` using the provided metric.
     ///
@@ -96,12 +96,8 @@ impl<K, M> BKTree<K, M>
     ///
     /// let tree: BKTree<&str> = BKTree::new(metrics::Levenshtein);
     /// ```
-    pub fn new(metric: M) -> BKTree<K, M>
-    {
-        BKTree {
-            root: None,
-            metric: metric,
-        }
+    pub fn new(metric: M) -> BKTree<K, M> {
+        BKTree { root: None, metric }
     }
 
     /// Adds a key to the tree.
@@ -174,14 +170,16 @@ impl<K, M> BKTree<K, M>
     /// assert!(tree.find("foz", 0).next().is_none());
     /// ```
     pub fn find<'a, 'q, Q: ?Sized>(&'a self, key: &'q Q, tolerance: u64) -> Find<'a, 'q, K, Q, M>
-        where K: Borrow<Q>, M: Metric<Q>
+    where
+        K: Borrow<Q>,
+        M: Metric<Q>,
     {
         Find {
             root: self.root.as_ref(),
             stack: Vec::new(),
-            tolerance: tolerance,
+            tolerance,
             metric: &self.metric,
-            key: key,
+            key,
         }
     }
 
@@ -204,7 +202,9 @@ impl<K, M> BKTree<K, M>
     /// assert_eq!(tree.find_exact("foo"), Some(&"foo"));
     /// ```
     pub fn find_exact<Q: ?Sized>(&self, key: &Q) -> Option<&K>
-        where K: Borrow<Q>, M: Metric<Q>
+    where
+        K: Borrow<Q>,
+        M: Metric<Q>,
     {
         self.find(key, 0).next().map(|(_, found_key)| found_key)
     }
@@ -239,8 +239,7 @@ impl<K: AsRef<str>> Default for BKTree<K> {
 }
 
 /// Iterator for the results of `BKTree::find`.
-pub struct Find<'a, 'q, K: 'a, Q: 'q + ?Sized, M: 'a>
-{
+pub struct Find<'a, 'q, K: 'a, Q: 'q + ?Sized, M: 'a> {
     /// Root node.
     root: Option<&'a BKNode<K>>,
     /// Iterator stack. Because of the inversion of control in play, we must
@@ -260,14 +259,15 @@ struct StackItem<'a, K: 'a> {
 /// Delayed action type. Because of Rust's borrowing rules, we can't inspect
 /// and modify the stack at the same time. We instead record the modification
 /// and apply it at the end of the procedure.
-enum StackAction<'a, K: 'a>
-{
+enum StackAction<'a, K: 'a> {
     Push(&'a BKNode<K>),
     Pop,
 }
 
 impl<'a, 'q, K, Q: ?Sized, M> Iterator for Find<'a, 'q, K, Q, M>
-    where K: Borrow<Q>, M: Metric<Q>
+where
+    K: Borrow<Q>,
+    M: Metric<Q>,
 {
     type Item = (u64, &'a K);
 
@@ -276,7 +276,7 @@ impl<'a, 'q, K, Q: ?Sized, M> Iterator for Find<'a, 'q, K, Q, M>
         if let Some(root) = self.root.take() {
             let cur_dist = self.metric.distance(self.key, root.key.borrow() as &Q);
             self.stack.push(StackItem {
-                cur_dist: cur_dist,
+                cur_dist,
                 children_iter: root.children.iter(),
             });
             if cur_dist <= self.tolerance {
@@ -298,26 +298,28 @@ impl<'a, 'q, K, Q: ?Sized, M> Iterator for Find<'a, 'q, K, Q, M>
                         }
                     }
                     action
-                },
+                }
                 None => return None,
             };
 
             match action {
                 StackAction::Push(child_node) => {
                     // Push this child node onto the stack (to inspect later)
-                    let cur_dist = self.metric.distance(self.key, child_node.key.borrow() as &Q);
+                    let cur_dist = self
+                        .metric
+                        .distance(self.key, child_node.key.borrow() as &Q);
                     self.stack.push(StackItem {
-                        cur_dist: cur_dist,
+                        cur_dist,
                         children_iter: child_node.children.iter(),
                     });
                     // If this node is also close enough to the key, yield it
                     if cur_dist <= self.tolerance {
                         return Some((cur_dist, &child_node.key));
                     }
-                },
+                }
                 StackAction::Pop => {
                     self.stack.pop();
-                },
+                }
             }
         }
     }
@@ -329,7 +331,9 @@ mod tests {
     use {BKNode, BKTree};
 
     fn assert_eq_sorted<'t, T: 't, I>(left: I, right: &[(u64, T)])
-        where T: Ord + Debug, I: Iterator<Item=(u64, &'t T)>
+    where
+        T: Ord + Debug,
+        I: Iterator<Item = (u64, &'t T)>,
     {
         let mut left_mut: Vec<_> = left.collect();
         let mut right_mut: Vec<_> = right.iter().map(|&(dist, ref key)| (dist, key)).collect();
@@ -360,8 +364,10 @@ mod tests {
         match tree.root {
             Some(ref root) => {
                 assert_eq!(root.key, "foo");
-            },
-            None => { assert!(false); }
+            }
+            None => {
+                assert!(false);
+            }
         }
         tree.add("fop");
         tree.add("f\u{e9}\u{e9}");
@@ -369,8 +375,10 @@ mod tests {
             Some(ref root) => {
                 assert_eq!(root.children.get(&1).unwrap().key, "fop");
                 assert_eq!(root.children.get(&2).unwrap().key, "f\u{e9}\u{e9}");
-            },
-            None => { assert!(false); }
+            }
+            None => {
+                assert!(false);
+            }
         }
     }
 
@@ -381,8 +389,10 @@ mod tests {
         match tree.root {
             Some(ref root) => {
                 assert_eq!(root.key, "foo");
-            },
-            None => { assert!(false); }
+            }
+            None => {
+                assert!(false);
+            }
         }
         assert_eq!(tree.root.unwrap().children.get(&1).unwrap().key, "fop");
     }
@@ -404,7 +414,16 @@ mod tests {
         tree.add("cart");
         assert_eq_sorted(tree.find("caqe", 1), &[(1, "cake"), (1, "cape")]);
         assert_eq_sorted(tree.find("cape", 1), &[(1, "cake"), (0, "cape")]);
-        assert_eq_sorted(tree.find("book", 1), &[(0, "book"), (1, "books"), (1, "boo"), (1, "boon"), (1, "cook")]);
+        assert_eq_sorted(
+            tree.find("book", 1),
+            &[
+                (0, "book"),
+                (1, "books"),
+                (1, "boo"),
+                (1, "boon"),
+                (1, "cook"),
+            ],
+        );
         assert_eq_sorted(tree.find("book", 0), &[(0, "book")]);
         assert!(tree.find("foobar", 1).next().is_none());
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,7 +1,6 @@
 //! This is a collection of string metrics that are suitable for use with a
 //! BK-tree.
 
-
 use std::cmp::min;
 
 use Metric;
@@ -26,8 +25,7 @@ use Metric;
 #[derive(Debug)]
 pub struct Levenshtein;
 
-impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein
-{
+impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein {
     fn distance(&self, a: &K, b: &K) -> u64 {
         let str_a: &str = a.as_ref();
         let str_b: &str = b.as_ref();


### PR DESCRIPTION
- Removes invalid documentation link
- Change multirust(deprecated) to rustup
- Run Rust format on all files
- Run Clippy and apply all rules
- Update Rand to 0.8.2 from 0.3 (Required change with Range `rng.gen_range(4..12);` instead `rng.gen_range(4, 12);` and also `rng.sample_iter(&Alphanumeric).take(l).map(char::from).collect();` instead non existing in 0.8 version `rng.gen_ascii_chars().take(l).collect();`)