### PR TITLE
Reworked find, optional FnvHash build feature, threshold optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bk-tree"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Eugene Bulkin <eugene.bulkin2@gmail.com>"]
 description = "A Rust BK-tree implementation"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ categories = ["data-structures", "text-processing"]
 
 [dependencies]
 fnv = { version = "1.0.7", optional = true }
+triple_accel = "0.3.4"
 
 [dev-dependencies]
 rand = "0.3"
 
 [features]
+default = ["enable-fnv"]
 enable-fnv = ["fnv"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,11 @@ license = "MIT"
 keywords = ["fuzzy", "search", "BK-tree"]
 categories = ["data-structures", "text-processing"]
 
+[dependencies]
+fnv = { version = "1.0.7", optional = true }
+
 [dev-dependencies]
 rand = "0.3"
+
+[features]
+enable-fnv = ["fnv"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,17 @@ use std::{
     fmt::{Debug, Formatter, Result as FmtResult},
     iter::Extend,
     borrow::Borrow,
-    collections::{VecDeque, HashMap},
+    collections::VecDeque,
 };
+
+#[cfg(feature = "enable-fnv")]
+extern crate fnv;
+#[cfg(feature = "enable-fnv")]
+use fnv::FnvHashMap;
+
+#[cfg(not(feature = "enable-fnv"))]
+use std::collections::HashMap;
+
 
 /// A trait for a *metric* (distance function).
 ///
@@ -27,15 +36,22 @@ struct BKNode<K> {
     key: K,
     /// A hash-map of children, indexed by their distance from this node based
     /// on the metric being used by the tree.
+    #[cfg(feature = "enable-fnv")]
+    children: FnvHashMap<u64, BKNode<K>>,
+    #[cfg(not(feature = "enable-fnv"))]
     children: HashMap<u64, BKNode<K>>,
 }
 
 impl<K> BKNode<K> {
     /// Constructs a new `BKNode<K>`.
     pub fn new(key: K) -> BKNode<K> {
+        #[cfg(feature = "enable-fnv")]
+        let children = fnv::FnvHashMap::default();
+        #[cfg(not(feature = "enable-fnv"))]
+        let children = HashMap::default();
         BKNode {
             key,
-            children: HashMap::new(),
+            children,
         }
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,10 +1,10 @@
 //! This is a collection of string metrics that are suitable for use with a
 //! BK-tree.
 
-
-use std::cmp::min;
-
 use Metric;
+
+extern crate triple_accel;
+use self::triple_accel::{levenshtein, levenshtein::levenshtein_simd_k};
 
 /// This calculates the Levenshtein distance between two strings.
 ///
@@ -28,54 +28,15 @@ pub struct Levenshtein;
 
 impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein
 {
-    fn distance(&self, a: &K, b: &K) -> u64 {
-        let str_a: &str = a.as_ref();
-        let str_b: &str = b.as_ref();
+    fn distance(&self, a: &K, b: &K) -> u32 {
+        let a_bytes = a.as_ref().as_bytes();
+        let b_bytes = b.as_ref().as_bytes();
+        levenshtein(a_bytes, b_bytes)
+    }
 
-        let len_a = str_a.chars().count();
-        let len_b = str_b.chars().count();
-        if len_a == 0 {
-            return len_b as u64;
-        }
-        if len_b == 0 {
-            return len_a as u64;
-        }
-
-        // This is a case-insensitive algorithm
-        let a_lower = str_a.to_lowercase();
-        let b_lower = str_b.to_lowercase();
-
-        // Initialize the array
-        let mut d: Vec<Vec<usize>> = Vec::new();
-        for j in 0..(len_b + 1) {
-            let mut cur_vec = Vec::new();
-            for i in 0..(len_a + 1) {
-                if j == 0 {
-                    cur_vec.push(i);
-                } else if i == 0 {
-                    cur_vec.push(j);
-                } else {
-                    cur_vec.push(0);
-                }
-            }
-            d.push(cur_vec);
-        }
-
-        for (j, chr_b) in b_lower.chars().enumerate() {
-            for (i, chr_a) in a_lower.chars().enumerate() {
-                if chr_a == chr_b {
-                    // If they're the same, then don't modify the value
-                    d[j + 1][i + 1] = d[j][i];
-                } else {
-                    // Otherwise, pick the lowest cost option for an error
-                    let deletion = d[j + 1][i] + 1;
-                    let insertion = d[j][i + 1] + 1;
-                    let substitution = d[j][i] + 1;
-                    d[j + 1][i + 1] = min(min(deletion, insertion), substitution);
-                }
-            }
-        }
-
-        d[len_b][len_a] as u64
+    fn threshold_distance(&self, a: &K, b: &K, threshold: u32) -> Option<u32> {
+        let a_bytes = a.as_ref().as_bytes();
+        let b_bytes = b.as_ref().as_bytes();
+        levenshtein_simd_k(a_bytes, b_bytes, threshold)
     }
 }


### PR DESCRIPTION
Hello Eugene!

Great work on your BK Tree library!

I've made a fork with a few modifications/additions.  My hope is that you and other users may find them useful.

Here are changes in my fork I'd like to propose:
- I've reworked some of the underlying `find` code to replace the existing stack abstraction with a simple `VecDeque`.
- I've added an optional crate feature named `enable-fnv` which replaces the uses of the standard library `HashMap` with `FnvHashMap`.  This presents a runtime benefit for users who prioritize runtime speed over DoS resistance.  I haven't looked into it yet, but there may be other similar opportunities with specialty hash maps, which could be explored as well.
- I added an algorithmic optimization which I haven't seen mentioned anywhere else.  I would like to create some kind of write-up at some point, but here is the summary:  by keeping track of each node's maximum child distance, you are able to limit the search space within find to `tolerance + max_child_distance`.  This may be slightly slower in some situations due to having to store and check a bit more, but can be very helpful in other situations.

Let me know what you think, and if you have any other ideas in mind!