### PR TITLE
WIP: Add serialization of trees that have serializable keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["fuzzy", "search", "BK-tree"]
 categories = ["data-structures", "text-processing"]
 
 [dependencies]
-bytes = "1.0.1"
 fnv = { version = "1.0.7", optional = true }
 triple_accel = "0.3.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["fuzzy", "search", "BK-tree"]
 categories = ["data-structures", "text-processing"]
 
 [dependencies]
+bytes = "1.0.1"
 fnv = { version = "1.0.7", optional = true }
 triple_accel = "0.3.4"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,27 @@ where
     {
         self.find(key, 0).next().map(|(_, found_key)| found_key)
     }
+
+    /// [Future] Return (probably something like) a `Result<BytesBuffer>`, the serialized bytes representation of `self`.
+    ///
+    /// See: https://eli.thegreenplace.net/2011/09/29/an-interesting-tree-serialization-algorithm-from-dwarf#id3
+    ///
+    /// [I still do not know what this algorithm is called!]
+    ///
+    /// For now we call this `to_bytes`. This is just a stub to get the serialization stuff off the ground.
+    pub fn to_bytes(&self) {
+	fn serialize<K> (node: &BKNode<K>) {
+	    if !node.children.is_empty() {
+		print!("|0--{:?}|CHILDREN_FOLLOW", "<node.key>");
+		for (dist, child_node) in node.children.iter() {
+		    serialize(child_node);
+		}
+	    } else {
+		print!("|0--{:?}|END_CHILDREN", "<node.key>");
+	    }
+	}
+	serialize(&self.root.as_ref().unwrap());
+    }
 }
 
 impl<K, M: Metric<K>> Extend<K> for BKTree<K, M> {
@@ -426,5 +447,31 @@ mod tests {
         assert_eq!(tree.find_exact("caqe"), None);
         assert_eq!(tree.find_exact("cape"), Some(&"cape"));
         assert_eq!(tree.find_exact("book"), Some(&"book"));
+    }
+
+    #[test]
+    fn tree_serialize() {
+        let mut tree_before: BKTree<&str> = Default::default();
+
+        tree_before.add("book");
+        tree_before.add("books");
+        tree_before.add("cake");
+        tree_before.add("boo");
+        tree_before.add("cape");
+        tree_before.add("boon");
+        tree_before.add("cook");
+        tree_before.add("cart");
+
+	println!("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+	tree_before.to_bytes();
+	println!("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+
+        assert_eq_sorted(tree_before.find("caqe", 1), &[(1, "cake"), (1, "cape")]);
+        assert_eq_sorted(tree_before.find("cape", 1), &[(1, "cake"), (0, "cape")]);
+
+	// let _serialized = tree_before.to_bytes();
+	// let tree_after = BKTree<&str>::from_bytes(serialized);
+        // assert_eq_sorted(tree_after.find("caqe", 1), &[(1, "cake"), (1, "cape")]);
+        // assert_eq_sorted(tree_after.find("cape", 1), &[(1, "cake"), (0, "cape")]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,16 +467,9 @@ mod tests {
         tree_before.add("cook");
         tree_before.add("cart");
 
-	println!("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
 	let _ = tree_before.to_bytes();
-	println!("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
 
         assert_eq_sorted(tree_before.find("caqe", 1), &[(1, "cake"), (1, "cape")]);
         assert_eq_sorted(tree_before.find("cape", 1), &[(1, "cake"), (0, "cape")]);
-
-	// let _serialized = tree_before.to_bytes();
-	// let tree_after = BKTree<&str>::from_bytes(serialized);
-        // assert_eq_sorted(tree_after.find("caqe", 1), &[(1, "cake"), (1, "cape")]);
-        // assert_eq_sorted(tree_after.find("cape", 1), &[(1, "cake"), (0, "cape")]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,14 +245,14 @@ where
     /// For now we call this `to_bytes`. This is just a stub to get the serialization stuff off the ground.
     pub fn to_bytes(&self) -> Bytes {
 	let mut mem = BytesMut::new();
-	fn serialize<K> (node: &BKNode<K>, mem2: &mut BytesMut) {
+	fn serialize<K> (node: &BKNode<K>, mem: &mut BytesMut) {
 	    if !node.children.is_empty() {
-		mem2.put(&b"|0--<node.key>|CHILDREN_FOLLOW"[..]);
+		mem.put(&b"|0--<node.key>|CHILDREN_FOLLOW"[..]);
 		for (_dist, child_node) in node.children.iter() {
-		    serialize(child_node, mem2);
+		    serialize(child_node, mem);
 		}
 	    } else {
-		mem2.put(&b"|0--<node.key>|END_CHILDREN"[..]);
+		mem.put(&b"|0--<node.key>|END_CHILDREN"[..]);
 	    }
 	}
 	let root = match self.root.as_ref() {


### PR DESCRIPTION
The idea is to support a dense, efficient serialization mechanism for `BKTree<K, M>` if the key type implements some kind of [de]serialization.

I would be grateful for any feedback on this. I am learning Rust and this feature idea for `bk_tree` came to mind via a separate project. I can imagine...

1. It's already handled somehow and I just don't know it
1. This should go in another library, maybe its own
1. It's grossly inefficient and ugly (...that's it! make me suffer!)
1. The plan itself has a fatal flaw

Anyway, please feel free to ignore this, outright reject it, or provide some feedback. I've had fun learning how `bk_tree` works!

> :warning: Known issue -- There is no practical way to encode a `Metric`. Or is there.