### PR TITLE
Do not add `BKNode` if `cur_dist == 0` (implying matching keys)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,10 @@ where
                     cur_node = next_node;
                     cur_dist = self.metric.distance(&cur_node.key, &key);
                 }
-                cur_node.add_child(cur_dist, key);
+                // If cur_dist == 0, we have landed on a node with the same key.
+                if cur_dist > 0 {
+                    cur_node.add_child(cur_dist, key);
+                }
             }
             None => {
                 self.root = Some(BKNode::new(key));
@@ -426,5 +429,13 @@ mod tests {
         assert_eq!(tree.find_exact("caqe"), None);
         assert_eq!(tree.find_exact("cape"), Some(&"cape"));
         assert_eq!(tree.find_exact("book"), Some(&"book"));
+    }
+
+    #[test]
+    fn one_node_tree() {
+        let mut tree: BKTree<&str> = Default::default();
+        tree.add("book");
+        tree.add("book");
+        assert_eq!(tree.root.unwrap().children.len(), 0);
     }
 }


### PR DESCRIPTION
It appears that `bk-node` is duplicating nodes in the tree. We are calling `add_child` from `add` even when `cur_dist == 0`.

I've confirmed that for example, without this fix, the following code

``` rust
use bk_tree::BKTree;
fn main() {
    let mut tree: BKTree<&str> = Default::default();
    tree.add("book");
    tree.add("book");
    println!("{:?}", tree.find("", 4).collect::<Vec<_>>());
}
```

gives output

```
[(4, "book"), (4, "book")]
```

Two entries with distance 4 found, both are `"book"`

The regression test for this is to add two identical nodes to an empty tree and confirm that `root.children.len() == 0`, which I've added.