### PR TITLE
Support serialization of nodes with serializable keys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ categories = ["data-structures", "text-processing"]
 [dependencies]
 fnv = { version = "1.0.7", optional = true }
 triple_accel = "0.3.4"
-serde_cbor = "0.11.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0.126"
+serde_cbor = { version = "0.11.1", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_derive = { version = "1.0.126", optional = true }
 
 [dev-dependencies]
 rand = "0.3"
@@ -25,3 +25,4 @@ rand = "0.3"
 [features]
 default = ["enable-fnv"]
 enable-fnv = ["fnv"]
+serde_x = ["serde", "serde_cbor", "serde_derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["data-structures", "text-processing"]
 [dependencies]
 fnv = { version = "1.0.7", optional = true }
 triple_accel = "0.3.4"
+serde_cbor = "0.11.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_derive = "1.0.126"
 
 [dev-dependencies]
 rand = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ rand = "0.3"
 [features]
 default = ["enable-fnv"]
 enable-fnv = ["fnv"]
-serde_x = ["serde", "serde_cbor", "serde_derive"]
+serde-support = ["serde", "serde_cbor", "serde_derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,13 +86,34 @@ impl<K> BKNode<K>
 where
     K: serde::Serialize + serde::de::DeserializeOwned,
 {
-    /// Recursively serialize a `BKNode` using [CBOR](https://en.wikipedia.org/wiki/CBOR),
-    /// returning the resulting bytes as `Vec<u8>`
+    /// Recursively serialize a `BKNode` using
+    /// [CBOR](https://en.wikipedia.org/wiki/CBOR),
+    /// returning the resulting bytes as `Vec<u8>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bk_tree::{BKTree, metrics};
+    ///
+    /// let mut tree: BKTree<String> = BKTree::new(metrics::Levenshtein);
+    /// tree.add("rust".to_string());
+    /// let serialized = &tree.root.unwrap().to_vec();
+    /// ```
     pub fn to_vec(&self) -> Result<Vec<u8>, serde_cbor::error::Error> {
         Ok(serde_cbor::to_vec(self)?)
     }
 
-    /// Deserialize a slice of `u8` into a returned `BKNode`
+    /// Deserialize a slice of `u8` into a returned `BKNode`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bk_tree::BKNode;
+    ///
+    /// let node = BKNode::new("box".to_string());
+    /// let serialized = &node.to_vec().unwrap();
+    /// let deserialized: BKNode<String> = BKNode::from_slice(serialized).unwrap();
+    /// ```
     pub fn from_slice<'a>(slice: &'a [u8]) -> Result<BKNode<K>, serde_cbor::error::Error> {
         let result: BKNode<K> = serde_cbor::from_slice(slice)?;
         Ok(result)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ mod tests {
 
     #[cfg(feature = "serde-support")]
     fn assert_serde_roundtrip(before: &BKNode<&str>) {
-	use tests::serde_cbor::{to_vec, from_slice};
+        use tests::serde_cbor::{to_vec, from_slice};
         let bytes: Vec<u8> = to_vec(&before).unwrap();
         assert!(bytes.len() > 0);
         let after: BKNode<&str> = from_slice(&bytes).unwrap();
@@ -449,7 +449,7 @@ mod tests {
     #[cfg(feature = "serde-support")]
     #[test]
     fn tree_serde() {
-	use self::serde_cbor::to_vec;
+        use self::serde_cbor::to_vec;
 
         let node: BKNode<&str> = BKNode::new("");
         assert_serde_roundtrip(&node);
@@ -476,12 +476,12 @@ mod tests {
         tree_same.add("cart");
         assert_serde_roundtrip(&tree_same.root.as_ref().unwrap());
 
-	// Two trees built using the same operations should be the same.
+        // Two trees built using the same operations should be the same.
         let bytes: Vec<u8> = to_vec(&tree.root).unwrap();
         let bytes_same: Vec<u8> = to_vec(&tree_same.root).unwrap();
         assert_eq!(bytes, bytes_same);
 
-	// FIXME: Changing insertion order of the above 2nd tree _does_ change the result. Do we care?
+        // FIXME: Changing insertion order of the above 2nd tree _does_ change the result. Do we care?
 
         // FIXME: Uncomment below when dups problem is resolved.
         // let mut tree1: BKTree<&str> = Default::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,11 +525,11 @@ mod tests {
         let mut new_tree: BKTree<String> = BKTree::default();
         new_tree.root = Some(node);
         assert_eq_sorted(new_tree.find("cereal", 0),
-			 &[(0, "cereal".to_string())]);
+                         &[(0, "cereal".to_string())]);
 
         // More tests?
         //   * Changing insertion order of the above 2nd tree changes the
-	//     serialization output. We should be able to scramble the order of
-	//     insertions for `tree_same` above and get the same serialization.
+        //     serialization output. We should be able to scramble the order of
+        //     insertions for `tree_same` above and get the same serialization.
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,11 +360,11 @@ mod tests {
 
 
     #[cfg(feature = "serde-support")]
-    fn assert_serde_roundtrip(before: &BKNode<&str>) {
+    fn assert_serde_roundtrip<'t, T: serde::Serialize + serde::Deserialize<'t>>(before: &BKNode<T>) {
         use tests::serde_cbor::{to_vec, from_slice};
         let bytes: Vec<u8> = to_vec(&before).unwrap();
         assert!(bytes.len() > 0);
-        let after: BKNode<&str> = from_slice(&bytes).unwrap();
+        let after: BKNode<T> = from_slice(&bytes).unwrap();
         let bytes_after: Vec<u8> = to_vec(&after).unwrap();
         assert_eq!(&bytes[..], &bytes_after[..]);
     }
@@ -477,30 +477,30 @@ mod tests {
         let node: BKNode<&str> = BKNode::new("");
         assert_serde_roundtrip(&node);
 
-        let mut tree: BKTree<&str> = Default::default();
-        tree.add("book");
-        tree.add("books");
-        tree.add("cake");
-        tree.add("boo");
-        tree.add("cape");
-        tree.add("boon");
-        tree.add("cook");
-        tree.add("cart");
+        let mut tree: BKTree<String> = Default::default();
+        tree.add("book".to_string());
+        tree.add("books".to_string());
+        tree.add("cake".to_string());
+        tree.add("boo".to_string());
+        tree.add("cape".to_string());
+        tree.add("boon".to_string());
+        tree.add("cook".to_string());
+        tree.add("cart".to_string());
         assert_serde_roundtrip(&tree.root.as_ref().unwrap());
 
-        let mut tree_same: BKTree<&str> = Default::default();
-        tree_same.add("book");
-        tree_same.add("books");
-        tree_same.add("cake");
-        tree_same.add("boo");
-        tree_same.add("cape");
-        tree_same.add("boon");
-        tree_same.add("cook");
-        tree_same.add("cart");
+        let mut tree_same: BKTree<String> = Default::default();
+        tree_same.add("book".to_string());
+        tree_same.add("books".to_string());
+        tree_same.add("cake".to_string());
+        tree_same.add("boo".to_string());
+        tree_same.add("cape".to_string());
+        tree_same.add("boon".to_string());
+        tree_same.add("cook".to_string());
+        tree_same.add("cart".to_string());
         assert_serde_roundtrip(&tree_same.root.as_ref().unwrap());
 
         // Two trees built using the same operations should be the same.
-        let bytes: Vec<u8> = to_vec(&tree.root).unwrap();
+        let bytes:      Vec<u8> = to_vec(&tree.root     ).unwrap();
         let bytes_same: Vec<u8> = to_vec(&tree_same.root).unwrap();
         assert_eq!(bytes, bytes_same);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,6 +318,8 @@ where
 mod tests {
     use std::fmt::Debug;
     use {BKNode, BKTree};
+    #[cfg(feature = "serde_x")]
+    extern crate serde_cbor;
 
     fn assert_eq_sorted<'t, T: 't, I>(left: I, right: &[(u32, T)])
     where
@@ -443,9 +445,6 @@ mod tests {
         assert_eq!(tree.find_exact("cape"), Some(&"cape"));
         assert_eq!(tree.find_exact("book"), Some(&"book"));
     }
-
-    #[cfg(feature = "serde_x")]
-    extern crate serde_cbor;
 
     #[cfg(feature = "serde_x")]
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ where
 impl<K, M> BKTree<K, M>
 where
     M: Metric<K>,
-    K: serde::Serialize + serde::Deserialize<'static>,
+    K: serde::Serialize + for <'de> serde::Deserialize<'de>,
 {
     pub fn to_vec(&self) -> Result<Option<Vec<u8>>, serde_cbor::error::Error> {
 	match &self.root {
@@ -257,8 +257,8 @@ where
 	}
     }
 
-    pub fn from_slice(slice: &'static [u8], metric: M) -> Result<BKTree<K, M>, serde_cbor::error::Error> {
-	Ok(BKTree{ metric, root: serde_cbor::from_slice(&slice)? })
+    pub fn from_slice<'a>(slice: &'a [u8], metric: M) -> Result<BKTree<K, M>, serde_cbor::error::Error> {
+	Ok(BKTree{ metric, root: serde_cbor::from_slice(slice)? })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,6 +457,24 @@ mod tests {
         tree.add("cart");
         assert_serde_roundtrip(&tree.root.as_ref().unwrap());
 
+        let mut tree_same: BKTree<&str> = Default::default();
+        tree_same.add("book");
+        tree_same.add("books");
+        tree_same.add("cake");
+        tree_same.add("boo");
+        tree_same.add("cape");
+        tree_same.add("boon");
+        tree_same.add("cook");
+        tree_same.add("cart");
+        assert_serde_roundtrip(&tree_same.root.as_ref().unwrap());
+
+	// Two trees built using the same operations should be the same.
+        let bytes: Vec<u8> = to_vec(&tree.root).unwrap();
+        let bytes_same: Vec<u8> = to_vec(&tree_same.root).unwrap();
+        assert_eq!(bytes, bytes_same);
+
+	// FIXME: Changing insertion order of the above 2nd tree _does_ change the result. Do we care?
+
         // FIXME: Uncomment below when dups problem is resolved.
         // let mut tree1: BKTree<&str> = Default::default();
         // tree1.add("book");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,6 @@ use std::collections::HashMap;
 
 #[cfg(feature = "serde-support")]
 extern crate serde_derive;
-#[cfg(feature = "serde-support")]
-use serde_derive::{Serialize, Deserialize};
 
 /// A trait for a *metric* (distance function).
 ///
@@ -36,7 +34,7 @@ pub trait Metric<K: ?Sized> {
 }
 
 /// A node within the [BK-tree](https://en.wikipedia.org/wiki/BK-tree).
-#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-support", derive(serde_derive::Serialize, serde_derive::Deserialize))]
 struct BKNode<K> {
     /// The key determining the node.
     key: K,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,6 +316,8 @@ where
 mod tests {
     use std::fmt::Debug;
     use {BKNode, BKTree};
+    extern crate serde_cbor;
+    use self::serde_cbor::{to_vec, from_slice};
 
     fn assert_eq_sorted<'t, T: 't, I>(left: I, right: &[(u32, T)])
     where
@@ -329,6 +331,14 @@ mod tests {
         right_mut.sort();
 
         assert_eq!(left_mut, right_mut);
+    }
+
+    fn assert_serde_roundtrip(before: BKNode<&str>) {
+        let bytes: Vec<u8> = to_vec(&before).unwrap();
+        let after: BKNode<&str> = from_slice(&bytes[..]).unwrap();
+        // Actually, it's before -> after -> after_again, because it's easier to compare two `Vec<u8>`
+        let bytes_after: Vec<u8> = to_vec(&after).unwrap();
+        assert_eq!(&bytes[..], &bytes_after[..]);
     }
 
     #[test]
@@ -429,5 +439,11 @@ mod tests {
         assert_eq!(tree.find_exact("caqe"), None);
         assert_eq!(tree.find_exact("cape"), Some(&"cape"));
         assert_eq!(tree.find_exact("book"), Some(&"book"));
+    }
+
+    #[test]
+    fn tree_serde() {
+        let node: BKNode<&str> = BKNode::new("foo");
+        assert_serde_roundtrip(node);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,8 +335,8 @@ mod tests {
 
     fn assert_serde_roundtrip(before: BKNode<&str>) {
         let bytes: Vec<u8> = to_vec(&before).unwrap();
-        let after: BKNode<&str> = from_slice(&bytes[..]).unwrap();
-        // Actually, it's before -> after -> after_again, because it's easier to compare two `Vec<u8>`
+        assert!(bytes.len() > 0);
+        let after: BKNode<&str> = from_slice(&bytes).unwrap();
         let bytes_after: Vec<u8> = to_vec(&after).unwrap();
         assert_eq!(&bytes[..], &bytes_after[..]);
     }
@@ -443,7 +443,28 @@ mod tests {
 
     #[test]
     fn tree_serde() {
-        let node: BKNode<&str> = BKNode::new("foo");
+        let node: BKNode<&str> = BKNode::new("");
         assert_serde_roundtrip(node);
+
+        let mut tree: BKTree<&str> = Default::default();
+        tree.add("book");
+        tree.add("books");
+        tree.add("cake");
+        tree.add("boo");
+        tree.add("cape");
+        tree.add("boon");
+        tree.add("cook");
+        tree.add("cart");
+        assert_serde_roundtrip(tree.root.unwrap());
+
+        // FIXME: Uncomment below when dups problem is resolved.
+        // let mut tree1: BKTree<&str> = Default::default();
+        // tree1.add("book");
+        // let mut tree2: BKTree<&str> = Default::default();
+        // tree2.add("book");
+        // tree2.add("book");
+        // let bytes1: Vec<u8> = to_vec(&tree1.root.unwrap()).unwrap();
+        // let bytes2: Vec<u8> = to_vec(&tree2.root.unwrap()).unwrap();
+        // assert_eq!(bytes1, bytes2);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,8 +494,17 @@ mod tests {
         let bytes_same: Vec<u8> = tree_same_root.to_vec().unwrap();
         assert_eq!(bytes, bytes_same);
 
+        // Ensure that we can use `serde_cbor` functions directly.
+        let mut tree: BKTree<String> = Default::default();
+        tree.add("cereal".to_string());
+        let bytes = serde_cbor::to_vec(&tree.root.unwrap()).unwrap();
+        let node: BKNode<String> = serde_cbor::from_slice(&bytes).unwrap();
+        let mut new_tree: BKTree<String> = BKTree::default();
+        new_tree.root = Some(node);
+        assert_eq_sorted(new_tree.find("cereal", 0), &[(0, "cereal".to_string())]);
+
         // More tests?
-	//   * Changing insertion order of the above 2nd tree _does_ change the result. We should be able to scramble
-	//     the order of insertions for `tree_same` above and get the same serialization.
+        //   * Changing insertion order of the above 2nd tree _does_ change the result. We should be able to scramble
+        //     the order of insertions for `tree_same` above and get the same serialization.
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ where
 impl<K, M> BKTree<K, M>
 where
     M: Metric<K>,
-    K: serde::Serialize + for <'de> serde::Deserialize<'de>,
+    K: serde::Serialize + serde::de::DeserializeOwned,
 {
     pub fn to_vec(&self) -> Result<Option<Vec<u8>>, serde_cbor::error::Error> {
 	match &self.root {
@@ -360,7 +360,7 @@ mod tests {
 
 
     #[cfg(feature = "serde-support")]
-    fn assert_serde_roundtrip<'t, T: serde::Serialize + serde::Deserialize<'t>>(before: &BKNode<T>) {
+    fn assert_serde_roundtrip<T: serde::Serialize + serde::de::DeserializeOwned>(before: &BKNode<T>) {
         use tests::serde_cbor::{to_vec, from_slice};
         let bytes: Vec<u8> = to_vec(&before).unwrap();
         assert!(bytes.len() > 0);
@@ -474,7 +474,7 @@ mod tests {
     fn tree_serde() {
         use self::serde_cbor::to_vec;
 
-        let node: BKNode<&str> = BKNode::new("");
+        let node: BKNode<String> = BKNode::new("".to_string());
         assert_serde_roundtrip(&node);
 
         let mut tree: BKTree<String> = Default::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,9 @@ use fnv::FnvHashMap;
 #[cfg(not(feature = "enable-fnv"))]
 use std::collections::HashMap;
 
+#[cfg(feature = "serde_x")]
 extern crate serde_derive;
+#[cfg(feature = "serde_x")]
 use serde_derive::{Serialize, Deserialize};
 
 /// A trait for a *metric* (distance function).
@@ -34,7 +36,7 @@ pub trait Metric<K: ?Sized> {
 }
 
 /// A node within the [BK-tree](https://en.wikipedia.org/wiki/BK-tree).
-#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "serde_x", derive(Serialize, Deserialize))]
 struct BKNode<K> {
     /// The key determining the node.
     key: K,
@@ -316,8 +318,6 @@ where
 mod tests {
     use std::fmt::Debug;
     use {BKNode, BKTree};
-    extern crate serde_cbor;
-    use self::serde_cbor::{to_vec, from_slice};
 
     fn assert_eq_sorted<'t, T: 't, I>(left: I, right: &[(u32, T)])
     where
@@ -333,7 +333,10 @@ mod tests {
         assert_eq!(left_mut, right_mut);
     }
 
+
+    #[cfg(feature = "serde_x")]
     fn assert_serde_roundtrip(before: &BKNode<&str>) {
+	use tests::serde_cbor::{to_vec, from_slice};
         let bytes: Vec<u8> = to_vec(&before).unwrap();
         assert!(bytes.len() > 0);
         let after: BKNode<&str> = from_slice(&bytes).unwrap();
@@ -441,8 +444,13 @@ mod tests {
         assert_eq!(tree.find_exact("book"), Some(&"book"));
     }
 
+    #[cfg(feature = "serde_x")]
+    extern crate serde_cbor;
+
+    #[cfg(feature = "serde_x")]
     #[test]
     fn tree_serde() {
+	use self::serde_cbor::to_vec;
         let node: BKNode<&str> = BKNode::new("");
         assert_serde_roundtrip(&node);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ use fnv::FnvHashMap;
 #[cfg(not(feature = "enable-fnv"))]
 use std::collections::HashMap;
 
-#[cfg(feature = "serde_x")]
+#[cfg(feature = "serde-support")]
 extern crate serde_derive;
-#[cfg(feature = "serde_x")]
+#[cfg(feature = "serde-support")]
 use serde_derive::{Serialize, Deserialize};
 
 /// A trait for a *metric* (distance function).
@@ -36,7 +36,7 @@ pub trait Metric<K: ?Sized> {
 }
 
 /// A node within the [BK-tree](https://en.wikipedia.org/wiki/BK-tree).
-#[cfg_attr(feature = "serde_x", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
 struct BKNode<K> {
     /// The key determining the node.
     key: K,
@@ -318,7 +318,7 @@ where
 mod tests {
     use std::fmt::Debug;
     use {BKNode, BKTree};
-    #[cfg(feature = "serde_x")]
+    #[cfg(feature = "serde-support")]
     extern crate serde_cbor;
 
     fn assert_eq_sorted<'t, T: 't, I>(left: I, right: &[(u32, T)])
@@ -336,7 +336,7 @@ mod tests {
     }
 
 
-    #[cfg(feature = "serde_x")]
+    #[cfg(feature = "serde-support")]
     fn assert_serde_roundtrip(before: &BKNode<&str>) {
 	use tests::serde_cbor::{to_vec, from_slice};
         let bytes: Vec<u8> = to_vec(&before).unwrap();
@@ -446,10 +446,11 @@ mod tests {
         assert_eq!(tree.find_exact("book"), Some(&"book"));
     }
 
-    #[cfg(feature = "serde_x")]
+    #[cfg(feature = "serde-support")]
     #[test]
     fn tree_serde() {
 	use self::serde_cbor::to_vec;
+
         let node: BKNode<&str> = BKNode::new("");
         assert_serde_roundtrip(&node);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,7 +333,7 @@ mod tests {
         assert_eq!(left_mut, right_mut);
     }
 
-    fn assert_serde_roundtrip(before: BKNode<&str>) {
+    fn assert_serde_roundtrip(before: &BKNode<&str>) {
         let bytes: Vec<u8> = to_vec(&before).unwrap();
         assert!(bytes.len() > 0);
         let after: BKNode<&str> = from_slice(&bytes).unwrap();
@@ -444,7 +444,7 @@ mod tests {
     #[test]
     fn tree_serde() {
         let node: BKNode<&str> = BKNode::new("");
-        assert_serde_roundtrip(node);
+        assert_serde_roundtrip(&node);
 
         let mut tree: BKTree<&str> = Default::default();
         tree.add("book");
@@ -455,7 +455,7 @@ mod tests {
         tree.add("boon");
         tree.add("cook");
         tree.add("cart");
-        assert_serde_roundtrip(tree.root.unwrap());
+        assert_serde_roundtrip(&tree.root.as_ref().unwrap());
 
         // FIXME: Uncomment below when dups problem is resolved.
         // let mut tree1: BKTree<&str> = Default::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub trait Metric<K: ?Sized> {
 
 /// A node within the [BK-tree](https://en.wikipedia.org/wiki/BK-tree).
 #[cfg_attr(feature = "serde-support", derive(serde_derive::Serialize, serde_derive::Deserialize))]
-struct BKNode<K> {
+pub struct BKNode<K> {
     /// The key determining the node.
     key: K,
     /// A hash-map of children, indexed by their distance from this node based
@@ -86,13 +86,13 @@ impl<K> BKNode<K>
 where
     K: serde::Serialize + serde::de::DeserializeOwned,
 {
-    fn to_vec(&self) -> Result<Vec<u8>, serde_cbor::error::Error> {
-	Ok(serde_cbor::to_vec(self)?)
+    pub fn to_vec(&self) -> Result<Vec<u8>, serde_cbor::error::Error> {
+        Ok(serde_cbor::to_vec(self)?)
     }
 
-    fn from_slice<'a>(slice: &'a [u8]) -> Result<BKNode<K>, serde_cbor::error::Error> {
-	let result: BKNode<K> = serde_cbor::from_slice(slice)?;
-	Ok(result)
+    pub fn from_slice<'a>(slice: &'a [u8]) -> Result<BKNode<K>, serde_cbor::error::Error> {
+        let result: BKNode<K> = serde_cbor::from_slice(slice)?;
+        Ok(result)
     }
 }
 
@@ -461,7 +461,7 @@ mod tests {
     #[cfg(feature = "serde-support")]
     #[test]
     fn tree_serde() {
-	let mut tree: BKTree<String> = BKTree::default();
+        let mut tree: BKTree<String> = BKTree::default();
         tree.add("".to_string());
         assert_serde_roundtrip(&tree.root.unwrap());
 
@@ -474,7 +474,7 @@ mod tests {
         tree.add("boon".to_string());
         tree.add("cook".to_string());
         tree.add("cart".to_string());
-	let tree_root = tree.root.unwrap();
+        let tree_root = tree.root.unwrap();
         assert_serde_roundtrip(&tree_root);
 
         let mut tree_same: BKTree<String> = Default::default();
@@ -486,7 +486,7 @@ mod tests {
         tree_same.add("boon".to_string());
         tree_same.add("cook".to_string());
         tree_same.add("cart".to_string());
-	let tree_same_root = tree_same.root.unwrap();
+        let tree_same_root = tree_same.root.unwrap();
         assert_serde_roundtrip(&tree_same_root);
 
         // Two trees built using the same operations should be the same.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,13 @@ impl<K> BKNode<K>
 where
     K: serde::Serialize + serde::de::DeserializeOwned,
 {
+    /// Recursively serialize a `BKNode` using [CBOR](https://en.wikipedia.org/wiki/CBOR),
+    /// returning the resulting bytes as `Vec<u8>`
     pub fn to_vec(&self) -> Result<Vec<u8>, serde_cbor::error::Error> {
         Ok(serde_cbor::to_vec(self)?)
     }
 
+    /// Deserialize a slice of `u8` into a returned `BKNode`
     pub fn from_slice<'a>(slice: &'a [u8]) -> Result<BKNode<K>, serde_cbor::error::Error> {
         let result: BKNode<K> = serde_cbor::from_slice(slice)?;
         Ok(result)
@@ -487,7 +490,6 @@ mod tests {
         tree_same.add("cook".to_string());
         tree_same.add("cart".to_string());
         let tree_same_root = tree_same.root.unwrap();
-        assert_serde_roundtrip(&tree_same_root);
 
         // Two trees built using the same operations should be the same.
         let bytes:      Vec<u8> = tree_root     .to_vec().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,10 +524,12 @@ mod tests {
         let node: BKNode<String> = serde_cbor::from_slice(&bytes).unwrap();
         let mut new_tree: BKTree<String> = BKTree::default();
         new_tree.root = Some(node);
-        assert_eq_sorted(new_tree.find("cereal", 0), &[(0, "cereal".to_string())]);
+        assert_eq_sorted(new_tree.find("cereal", 0),
+			 &[(0, "cereal".to_string())]);
 
         // More tests?
-        //   * Changing insertion order of the above 2nd tree _does_ change the result. We should be able to scramble
-        //     the order of insertions for `tree_same` above and get the same serialization.
+        //   * Changing insertion order of the above 2nd tree changes the
+	//     serialization output. We should be able to scramble the order of
+	//     insertions for `tree_same` above and get the same serialization.
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,6 +239,27 @@ where
     }
 }
 
+#[cfg(feature = "serde-support")]
+impl<K, M> BKTree<K, M>
+where
+    M: Metric<K>,
+    K: serde::Serialize,
+{
+    pub fn to_vec(&self) -> Result<Vec<u8>, &str> {
+	match &self.root {
+	    Some(node) => {
+		match serde_cbor::to_vec(node) {
+		    Ok(bytes) => { return Ok(bytes) },
+		    Err(e) => { return Err("some other err") }
+		}
+	    },
+	    None => {
+		return Err("foo");
+	    }
+	};
+    }
+}
+
 impl<K, M: Metric<K>> Extend<K> for BKTree<K, M> {
     /// Adds multiple keys to the tree.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,16 +494,8 @@ mod tests {
         let bytes_same: Vec<u8> = tree_same_root.to_vec().unwrap();
         assert_eq!(bytes, bytes_same);
 
-        // FIXME: Changing insertion order of the above 2nd tree _does_ change the result. Do we care?
-
-        // FIXME: Uncomment below when dups problem is resolved.
-        // let mut tree1: BKTree<&str> = Default::default();
-        // tree1.add("book");
-        // let mut tree2: BKTree<&str> = Default::default();
-        // tree2.add("book");
-        // tree2.add("book");
-        // let bytes1: Vec<u8> = to_vec(&tree1.root.unwrap()).unwrap();
-        // let bytes2: Vec<u8> = to_vec(&tree2.root.unwrap()).unwrap();
-        // assert_eq!(bytes1, bytes2);
+        // More tests?
+	//   * Changing insertion order of the above 2nd tree _does_ change the result. We should be able to scramble
+	//     the order of insertions for `tree_same` above and get the same serialization.
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ where
 #[derive(Debug)]
 pub struct BKTree<K, M = metrics::Levenshtein> {
     /// The root node. May be empty if nothing has been put in the tree yet.
-    root: Option<BKNode<K>>,
+    pub root: Option<BKNode<K>>,
     /// The metric being used to determine the distance between nodes on the
     /// tree.
     metric: M,


### PR DESCRIPTION
Adding methods `.to_vec` and `.from_slice`  to `BKNode` a la the [`serde_cbor`](https://github.com/pyfisch/cbor/tree/v0.11.1).