### PR TITLE
Add serialization and deserialization support to BKTree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,4 @@ bincode = "1.3"
 [features]
 default = ["enable-fnv"]
 enable-fnv = ["fnv"]
-serde-support = ["serde"]
-
+serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["data-structures", "text-processing"]
 [dependencies]
 fnv = { version = "1.0.7", optional = true }
 triple_accel = "0.3.4"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 rand = "0.3"
@@ -24,3 +24,4 @@ bincode = "1.3"
 [features]
 default = ["enable-fnv"]
 enable-fnv = ["fnv"]
+serde-support = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ categories = ["data-structures", "text-processing"]
 [dependencies]
 fnv = { version = "1.0.7", optional = true }
 triple_accel = "0.3.4"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.3"
+bincode = "1.3"
 
 [features]
 default = ["enable-fnv"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bk-tree"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Eugene Bulkin <eugene.bulkin2@gmail.com>"]
 description = "A Rust BK-tree implementation"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ bincode = "1.3"
 default = ["enable-fnv"]
 enable-fnv = ["fnv"]
 serde-support = ["serde"]
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
+#[cfg(feature = "serde-support")]
 extern crate serde;
 pub mod metrics;
 
-use serde::{Deserialize, Serialize};
 use std::{
     borrow::Borrow,
     collections::VecDeque,
@@ -32,8 +32,11 @@ pub trait Metric<K: ?Sized> {
     fn threshold_distance(&self, a: &K, b: &K, threshold: u32) -> Option<u32>;
 }
 
-#[derive(Serialize, Deserialize)]
 /// A node within the [BK-tree](https://en.wikipedia.org/wiki/BK-tree).
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 struct BKNode<K> {
     /// The key determining the node.
     key: K,
@@ -90,7 +93,10 @@ where
 }
 
 /// A representation of a [BK-tree](https://en.wikipedia.org/wiki/BK-tree).
-#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct BKTree<K, M = metrics::Levenshtein> {
     /// The root node. May be empty if nothing has been put in the tree yet.
     root: Option<BKNode<K>>,
@@ -445,6 +451,7 @@ mod tests {
         assert_eq!(tree.root.unwrap().children.len(), 0);
     }
 
+    #[cfg(feature = "serde-support")]
     #[test]
     fn test_serialization() {
         let mut tree: BKTree<&str> = Default::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
+extern crate serde;
 pub mod metrics;
 
+use serde::{Deserialize, Serialize};
 use std::{
-    fmt::{Debug, Formatter, Result as FmtResult},
-    iter::Extend,
     borrow::Borrow,
     collections::VecDeque,
+    fmt::{Debug, Formatter, Result as FmtResult},
+    iter::Extend,
 };
 
 #[cfg(feature = "enable-fnv")]
@@ -14,7 +16,6 @@ use fnv::FnvHashMap;
 
 #[cfg(not(feature = "enable-fnv"))]
 use std::collections::HashMap;
-
 
 /// A trait for a *metric* (distance function).
 ///
@@ -31,6 +32,7 @@ pub trait Metric<K: ?Sized> {
     fn threshold_distance(&self, a: &K, b: &K, threshold: u32) -> Option<u32>;
 }
 
+#[derive(Serialize, Deserialize)]
 /// A node within the [BK-tree](https://en.wikipedia.org/wiki/BK-tree).
 struct BKNode<K> {
     /// The key determining the node.
@@ -88,7 +90,7 @@ where
 }
 
 /// A representation of a [BK-tree](https://en.wikipedia.org/wiki/BK-tree).
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BKTree<K, M = metrics::Levenshtein> {
     /// The root node. May be empty if nothing has been put in the tree yet.
     root: Option<BKNode<K>>,
@@ -290,9 +292,11 @@ where
                 max_child_distance,
             } = current;
             let distance_cutoff = max_child_distance.unwrap_or(0) + self.tolerance;
-            let cur_dist = self.metric.threshold_distance(self.key,
-                                                          current.key.borrow() as &Q,
-                                                          distance_cutoff);
+            let cur_dist = self.metric.threshold_distance(
+                self.key,
+                current.key.borrow() as &Q,
+                distance_cutoff,
+            );
             if let Some(dist) = cur_dist {
                 // Find the first child node within an appropriate distance
                 let min_dist = dist.saturating_sub(self.tolerance);
@@ -314,6 +318,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    extern crate bincode;
+
     use std::fmt::Debug;
     use {BKNode, BKTree};
 
@@ -437,5 +443,71 @@ mod tests {
         tree.add("book");
         tree.add("book");
         assert_eq!(tree.root.unwrap().children.len(), 0);
+    }
+
+    #[test]
+    fn test_serialization() {
+        let mut tree: BKTree<&str> = Default::default();
+        tree.add("book");
+        tree.add("books");
+        tree.add("cake");
+        tree.add("boo");
+        tree.add("cape");
+        tree.add("boon");
+        tree.add("cook");
+        tree.add("cart");
+
+        // Test exact search (zero tolerance)
+        assert_eq_sorted(tree.find("book", 0), &[(0, "book")]);
+        assert_eq_sorted(tree.find("books", 0), &[(0, "books")]);
+        assert_eq_sorted(tree.find("cake", 0), &[(0, "cake")]);
+        assert_eq_sorted(tree.find("boo", 0), &[(0, "boo")]);
+        assert_eq_sorted(tree.find("cape", 0), &[(0, "cape")]);
+        assert_eq_sorted(tree.find("boon", 0), &[(0, "boon")]);
+        assert_eq_sorted(tree.find("cook", 0), &[(0, "cook")]);
+        assert_eq_sorted(tree.find("cart", 0), &[(0, "cart")]);
+
+        // Test fuzzy search
+        assert_eq_sorted(
+            tree.find("book", 1),
+            &[
+                (0, "book"),
+                (1, "books"),
+                (1, "boo"),
+                (1, "boon"),
+                (1, "cook"),
+            ],
+        );
+
+        // Test for false positives
+        assert_eq!(None, tree.find_exact("This &str hasn't been added"));
+
+        let encoded_tree: Vec<u8> = bincode::serialize(&tree).unwrap();
+        let decoded_tree: BKTree<&str> = bincode::deserialize(&encoded_tree[..]).unwrap();
+
+        // Test exact search (zero tolerance)
+        assert_eq_sorted(tree.find("book", 0), &[(0, "book")]);
+        assert_eq_sorted(tree.find("books", 0), &[(0, "books")]);
+        assert_eq_sorted(tree.find("cake", 0), &[(0, "cake")]);
+        assert_eq_sorted(tree.find("boo", 0), &[(0, "boo")]);
+        assert_eq_sorted(tree.find("cape", 0), &[(0, "cape")]);
+        assert_eq_sorted(tree.find("boon", 0), &[(0, "boon")]);
+        assert_eq_sorted(tree.find("cook", 0), &[(0, "cook")]);
+        assert_eq_sorted(tree.find("cart", 0), &[(0, "cart")]);
+
+        // Test fuzzy search
+        assert_eq_sorted(
+            decoded_tree.find("book", 1),
+            &[
+                (0, "book"),
+                (1, "books"),
+                (1, "boo"),
+                (1, "boon"),
+                (1, "cook"),
+            ],
+        );
+
+        // Test for false positives
+        assert_eq!(None, tree.find_exact("This &str hasn't been added"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 extern crate serde;
 pub mod metrics;
 
@@ -33,10 +33,7 @@ pub trait Metric<K: ?Sized> {
 }
 
 /// A node within the [BK-tree](https://en.wikipedia.org/wiki/BK-tree).
-#[cfg_attr(
-    feature = "serde-support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct BKNode<K> {
     /// The key determining the node.
     key: K,
@@ -93,10 +90,7 @@ where
 }
 
 /// A representation of a [BK-tree](https://en.wikipedia.org/wiki/BK-tree).
-#[cfg_attr(
-    feature = "serde-support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BKTree<K, M = metrics::Levenshtein> {
     /// The root node. May be empty if nothing has been put in the tree yet.
     root: Option<BKNode<K>>,
@@ -451,7 +445,7 @@ mod tests {
         assert_eq!(tree.root.unwrap().children.len(), 0);
     }
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serialization() {
         let mut tree: BKTree<&str> = Default::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,14 +486,14 @@ mod tests {
         let decoded_tree: BKTree<&str> = bincode::deserialize(&encoded_tree[..]).unwrap();
 
         // Test exact search (zero tolerance)
-        assert_eq_sorted(tree.find("book", 0), &[(0, "book")]);
-        assert_eq_sorted(tree.find("books", 0), &[(0, "books")]);
-        assert_eq_sorted(tree.find("cake", 0), &[(0, "cake")]);
-        assert_eq_sorted(tree.find("boo", 0), &[(0, "boo")]);
-        assert_eq_sorted(tree.find("cape", 0), &[(0, "cape")]);
-        assert_eq_sorted(tree.find("boon", 0), &[(0, "boon")]);
-        assert_eq_sorted(tree.find("cook", 0), &[(0, "cook")]);
-        assert_eq_sorted(tree.find("cart", 0), &[(0, "cart")]);
+        assert_eq_sorted(decoded_tree.find("book", 0), &[(0, "book")]);
+        assert_eq_sorted(decoded_tree.find("books", 0), &[(0, "books")]);
+        assert_eq_sorted(decoded_tree.find("cake", 0), &[(0, "cake")]);
+        assert_eq_sorted(decoded_tree.find("boo", 0), &[(0, "boo")]);
+        assert_eq_sorted(decoded_tree.find("cape", 0), &[(0, "cape")]);
+        assert_eq_sorted(decoded_tree.find("boon", 0), &[(0, "boon")]);
+        assert_eq_sorted(decoded_tree.find("cook", 0), &[(0, "cook")]);
+        assert_eq_sorted(decoded_tree.find("cart", 0), &[(0, "cart")]);
 
         // Test fuzzy search
         assert_eq_sorted(
@@ -508,6 +508,6 @@ mod tests {
         );
 
         // Test for false positives
-        assert_eq!(None, tree.find_exact("This &str hasn't been added"));
+        assert_eq!(None, decoded_tree.find_exact("This &str hasn't been added"));
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,7 +1,9 @@
 //! This is a collection of string metrics that are suitable for use with a
 //! BK-tree.
 
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde-support")]
+extern crate serde;
+
 use Metric;
 
 extern crate triple_accel;
@@ -24,7 +26,10 @@ use self::triple_accel::{levenshtein, levenshtein::levenshtein_simd_k};
 ///
 /// [1]: https://en.wikipedia.org/wiki/Levenshtein_distance
 /// [2]: https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm
-#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "serde-support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct Levenshtein;
 
 impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,7 @@
 //! This is a collection of string metrics that are suitable for use with a
 //! BK-tree.
 
+use serde::{Deserialize, Serialize};
 use Metric;
 
 extern crate triple_accel;
@@ -23,11 +24,10 @@ use self::triple_accel::{levenshtein, levenshtein::levenshtein_simd_k};
 ///
 /// [1]: https://en.wikipedia.org/wiki/Levenshtein_distance
 /// [2]: https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Levenshtein;
 
-impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein
-{
+impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein {
     fn distance(&self, a: &K, b: &K) -> u32 {
         let a_bytes = a.as_ref().as_bytes();
         let b_bytes = b.as_ref().as_bytes();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,7 +1,7 @@
 //! This is a collection of string metrics that are suitable for use with a
 //! BK-tree.
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 extern crate serde;
 
 use Metric;
@@ -26,10 +26,7 @@ use self::triple_accel::{levenshtein, levenshtein::levenshtein_simd_k};
 ///
 /// [1]: https://en.wikipedia.org/wiki/Levenshtein_distance
 /// [2]: https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm
-#[cfg_attr(
-    feature = "serde-support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Levenshtein;
 
 impl<K: AsRef<str> + ?Sized> Metric<K> for Levenshtein {


### PR DESCRIPTION
This PR changes the structs `BKNode`, `BKTree`, and `Levenshtein` to add support for deriving `serde`'s `Serialize` and `Deserialize` traits with the `serde-support` feature. Tests have been added to confirm that a BKTree that has been serialized and deserialized retains is equivalent to before those operations.