### PR TITLE
used correct struct name Levenshtein in Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here's some example usages:
 use bk_tree::{BKTree, metrics};
 
 // A BK-tree using the Levenshtein distance metric.
-let mut tree: BKTree<&str> = BKTree::new(metrics::levenshtein);
+let mut tree: BKTree<&str> = BKTree::new(metrics::Levenshtein);
 
 tree.add("foo");
 tree.add("bar");


### PR DESCRIPTION
just a typo fix for using the struct:

https://github.com/eugene-bulkin/rust-bk-tree/blob/3292a77ef7b452af845532347ef175e292c9e058/src/metrics.rs#L30